### PR TITLE
Fee payer key matching

### DIFF
--- a/tools-cli/src/main/java/com/hedera/hashgraph/client/cli/options/GetAccountInfoCommand.java
+++ b/tools-cli/src/main/java/com/hedera/hashgraph/client/cli/options/GetAccountInfoCommand.java
@@ -23,7 +23,7 @@ import com.hedera.hashgraph.client.core.exceptions.HederaClientRuntimeException;
 import com.hedera.hashgraph.client.core.json.Identifier;
 import com.hedera.hashgraph.client.core.security.Ed25519KeyStore;
 import com.hedera.hashgraph.client.core.utils.CommonMethods;
-import com.hedera.hashgraph.client.core.utils.JsonUtils;
+import com.hedera.hashgraph.client.core.utils.EncryptionUtils;
 import com.hedera.hashgraph.sdk.AccountId;
 import com.hedera.hashgraph.sdk.AccountInfo;
 import com.hedera.hashgraph.sdk.AccountInfoQuery;
@@ -34,7 +34,6 @@ import io.grpc.StatusRuntimeException;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-
 import picocli.CommandLine;
 
 import java.io.File;
@@ -105,7 +104,7 @@ public class GetAccountInfoCommand implements ToolCommand {
 				}
 				final var id = Identifier.parse(account).asAccount();
 				final AccountInfo accountInfo = getAccountInfo(client, id);
-				writeJsonObject(String.format("%s/%s.json", directory, id), JsonUtils.accountInfoToJson(accountInfo));
+				writeJsonObject(String.format("%s/%s.json", directory, id), EncryptionUtils.info2Json(accountInfo));
 				writeBytes(String.format("%s/%s.info", directory, id), accountInfo.toBytes());
 
 				logger.info("Account information for account {} has been written to file {}/{}.info", id, directory,

--- a/tools-core/src/main/java/com/hedera/hashgraph/client/core/constants/Constants.java
+++ b/tools-core/src/main/java/com/hedera/hashgraph/client/core/constants/Constants.java
@@ -86,7 +86,6 @@ public class Constants {
 	// region APP DEFAULTS
 	public static final boolean DEVELOPMENT = false;
 	public static final int DRIVE_LIMIT = 32;
-	public static final double RELOAD_PERIOD = 1.0; //One minute
 	public static final int KEYS_COLUMNS = 5;
 	public static final String TEST_PASSWORD = "123456789";
 	public static final String COMMA_DELIMITER = ",";

--- a/tools-core/src/main/java/com/hedera/hashgraph/client/core/remote/BatchFile.java
+++ b/tools-core/src/main/java/com/hedera/hashgraph/client/core/remote/BatchFile.java
@@ -53,7 +53,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 
-import java.awt.Desktop;
+import java.awt.*;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
@@ -358,7 +358,7 @@ public class BatchFile extends RemoteFile {
 	private boolean checkFee(final List<String> csvList) {
 		try {
 			final var feeLine = getStrings(csvList, TRANSACTION_FEE, "[,]", true);
-			// If there is no transaction fee line, just use the default;
+			// If there is no transaction fee line, just use the default
 			if (feeLine.length == 0) {
 				this.transactionFee = properties.getDefaultTxFee();
 				return false;
@@ -386,7 +386,7 @@ public class BatchFile extends RemoteFile {
 	private boolean checkTransactionValidDuration(final List<String> csvList) {
 		try {
 			final var tvdLine = getStrings(csvList, DURATION, "[,]", true);
-			// If there is no transaction valid duration line, just use the default;
+			// If there is no transaction valid duration line, just use the default
 			if (tvdLine.length == 0) {
 				this.txValidDuration = properties.getTxValidDuration();
 				return false;
@@ -631,7 +631,10 @@ public class BatchFile extends RemoteFile {
 
 	@Override
 	public Set<AccountId> getSigningAccounts() {
-		return new HashSet<>(Collections.singleton(getSenderAccountID().asAccount()));
+		final var set = new HashSet<AccountId>();
+		set.add(getSenderAccountID().asAccount());
+		set.add(getFeePayerAccountID().asAccount());
+		return set;
 	}
 
 	@Override

--- a/tools-core/src/main/java/com/hedera/hashgraph/client/core/remote/RemoteFilesMap.java
+++ b/tools-core/src/main/java/com/hedera/hashgraph/client/core/remote/RemoteFilesMap.java
@@ -29,7 +29,6 @@ import java.io.File;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -421,10 +420,10 @@ public class RemoteFilesMap {
 	private static boolean validFile(final FileDetails file) {
 		final var extension = file.getExtension();
 
-		for (final var type : FileType.values()) {
-			if (type.getExtension().equals(extension)) {
-				return true;
-			}
+		try {
+			return FileType.getType(extension) != FileType.UNKNOWN;
+		} catch (HederaClientException e) {
+			// No need to log or deal with this exception, the extension is invalid, return false
 		}
 		return false;
 	}

--- a/tools-core/src/main/java/com/hedera/hashgraph/client/core/transactions/ToolCryptoCreateTransaction.java
+++ b/tools-core/src/main/java/com/hedera/hashgraph/client/core/transactions/ToolCryptoCreateTransaction.java
@@ -28,7 +28,7 @@ import com.hedera.hashgraph.client.core.json.Identifier;
 import com.hedera.hashgraph.client.core.utils.EncryptionUtils;
 import com.hedera.hashgraph.sdk.AccountCreateTransaction;
 import com.hedera.hashgraph.sdk.Hbar;
-import com.hedera.hashgraph.sdk.KeyList;
+import com.hedera.hashgraph.sdk.Key;
 import com.hedera.hashgraph.sdk.Transaction;
 import com.hedera.hashgraph.sdk.TransactionId;
 import org.apache.logging.log4j.LogManager;
@@ -58,7 +58,7 @@ import static com.hedera.hashgraph.client.core.utils.JsonUtils.jsonToHBars;
 public class ToolCryptoCreateTransaction extends ToolTransaction {
 
 	private Hbar initialBalance;
-	private KeyList key;
+	private Key key;
 	private Duration autoRenewDuration;
 	private boolean receiverSignatureRequired;
 	private int maxTokenAssociations = MAX_TOKEN_AUTOMATIC_ASSOCIATIONS;
@@ -77,7 +77,7 @@ public class ToolCryptoCreateTransaction extends ToolTransaction {
 	public ToolCryptoCreateTransaction(final File inputFile) throws HederaClientException {
 		super(inputFile);
 		this.initialBalance = ((AccountCreateTransaction) transaction).getInitialBalance();
-		this.key = (KeyList) ((AccountCreateTransaction) transaction).getKey();
+		this.key = ((AccountCreateTransaction) transaction).getKey();
 		this.autoRenewDuration = ((AccountCreateTransaction) transaction).getAutoRenewPeriod();
 		this.receiverSignatureRequired = ((AccountCreateTransaction) transaction).getReceiverSignatureRequired();
 		this.maxTokenAssociations = ((AccountCreateTransaction) transaction).getMaxAutomaticTokenAssociations();
@@ -93,7 +93,7 @@ public class ToolCryptoCreateTransaction extends ToolTransaction {
 		return initialBalance;
 	}
 
-	public KeyList getKey() {
+	public Key getKey() {
 		return key;
 	}
 

--- a/tools-core/src/main/java/com/hedera/hashgraph/client/core/transactions/ToolCryptoUpdateTransaction.java
+++ b/tools-core/src/main/java/com/hedera/hashgraph/client/core/transactions/ToolCryptoUpdateTransaction.java
@@ -29,7 +29,7 @@ import com.hedera.hashgraph.client.core.utils.CommonMethods;
 import com.hedera.hashgraph.client.core.utils.EncryptionUtils;
 import com.hedera.hashgraph.sdk.AccountId;
 import com.hedera.hashgraph.sdk.AccountUpdateTransaction;
-import com.hedera.hashgraph.sdk.KeyList;
+import com.hedera.hashgraph.sdk.Key;
 import com.hedera.hashgraph.sdk.Transaction;
 import com.hedera.hashgraph.sdk.TransactionId;
 import org.apache.logging.log4j.LogManager;
@@ -57,7 +57,7 @@ import static com.hedera.hashgraph.client.core.constants.JsonConstants.STAKED_NO
 public class ToolCryptoUpdateTransaction extends ToolTransaction {
 
 	private Identifier account;
-	private KeyList key;
+	private Key key;
 	private Duration autoRenewDuration;
 	private Boolean receiverSignatureRequired;
 	private Integer maxTokenAssociations;
@@ -77,7 +77,7 @@ public class ToolCryptoUpdateTransaction extends ToolTransaction {
 	public ToolCryptoUpdateTransaction(final File inputFile) throws HederaClientException {
 		super(inputFile);
 		this.account = new Identifier(((AccountUpdateTransaction) transaction).getAccountId());
-		this.key = (KeyList) ((AccountUpdateTransaction) transaction).getKey();
+		this.key = ((AccountUpdateTransaction) transaction).getKey();
 		this.autoRenewDuration = ((AccountUpdateTransaction) transaction).getAutoRenewPeriod();
 		this.receiverSignatureRequired = ((AccountUpdateTransaction) transaction).getReceiverSignatureRequired();
 		this.maxTokenAssociations = ((AccountUpdateTransaction) transaction).getMaxAutomaticTokenAssociations();
@@ -93,7 +93,7 @@ public class ToolCryptoUpdateTransaction extends ToolTransaction {
 		setTransactionType(TransactionType.CRYPTO_UPDATE);
 	}
 
-	public KeyList getKey() {
+	public Key getKey() {
 		return key;
 	}
 

--- a/tools-core/src/main/java/com/hedera/hashgraph/client/core/utils/EncryptionUtils.java
+++ b/tools-core/src/main/java/com/hedera/hashgraph/client/core/utils/EncryptionUtils.java
@@ -176,33 +176,28 @@ public class EncryptionUtils {
 	}
 
 	/**
-	 * Converts a json object to a com.hedera.hashgraph.sdk.KeyList object
+	 * Converts a json object to a com.hedera.hashgraph.sdk.Key object
 	 *
 	 * @param jsonObject
 	 * 		a json object representing a key
 	 * @return the key represented by the json object
 	 */
-	public static KeyList jsonToKey(final JsonObject jsonObject) {
-
-		var keyList = new KeyList();
+	public static Key jsonToKey(final JsonObject jsonObject) {
 		if (jsonObject.has(ED_25519)) {
 			final var ed = jsonObject.get(ED_25519).getAsString();
-			final var publicKey = PublicKey.fromString(ed);
-			keyList = new KeyList();
-			keyList.add(publicKey);
+			return PublicKey.fromString(ed);
 		} else if (jsonObject.has("key")) {
 			final var pubKeyFile = jsonObject.get("key").getAsString();
-			final var publicKey = publicKeyFromFile(pubKeyFile);
-			keyList = new KeyList();
-			keyList.add(publicKey);
+			return publicKeyFromFile(pubKeyFile);
 		} else if (jsonObject.has(KEY_LIST)) {
 			if (jsonObject.get(KEY_LIST) instanceof JsonArray) {
-				keyList = jsonKeyListToSDKKeyList(jsonObject.getAsJsonArray(KEY_LIST));
+				return jsonKeyListToSDKKeyList(jsonObject.getAsJsonArray(KEY_LIST));
 			}
 		} else if (jsonObject.has(THRESHOLD_KEY)) {
-			keyList = (KeyList) jsonThresholdKeyToSDKKeyList(jsonObject.get(THRESHOLD_KEY).getAsJsonObject());
+			return jsonThresholdKeyToSDKKeyList(jsonObject.get(THRESHOLD_KEY).getAsJsonObject());
 		}
-		return keyList;
+		// If nothing worked, return an empty key
+		return new KeyList();
 	}
 
 	/**

--- a/tools-ui/src/main/java/com/hedera/hashgraph/client/ui/AccountsPaneController.java
+++ b/tools-ui/src/main/java/com/hedera/hashgraph/client/ui/AccountsPaneController.java
@@ -22,7 +22,6 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
-import com.hedera.hashgraph.client.core.action.GenericFileReadWriteAware;
 import com.hedera.hashgraph.client.core.enums.NetworkEnum;
 import com.hedera.hashgraph.client.core.enums.SetupPhase;
 import com.hedera.hashgraph.client.core.exceptions.HederaClientException;
@@ -158,7 +157,7 @@ import static java.lang.String.valueOf;
 import static java.lang.Thread.sleep;
 
 
-public class AccountsPaneController implements GenericFileReadWriteAware {
+public class AccountsPaneController implements SubController {
 
 	private static final Logger logger = LogManager.getLogger(AccountsPaneController.class);
 	public static final String PATH_NAME_EXTENSION = "%s%s.%s";
@@ -232,7 +231,8 @@ public class AccountsPaneController implements GenericFileReadWriteAware {
 		this.controller = controller;
 	}
 
-	void initializeAccountPane() {
+	@Override
+	public void initializePane() {
 		hiddenPathAccount.clear();
 
 		fixAccountFiles();
@@ -1112,7 +1112,7 @@ public class AccountsPaneController implements GenericFileReadWriteAware {
 		} catch (final HederaClientException e) {
 			logger.error("IO Error during zip process");
 		}
-		controller.createPaneController.initializeCreatePane();
+		controller.createPaneController.initializePane();
 	}
 
 	private void removeDefaultFeePayer() {
@@ -1121,7 +1121,7 @@ public class AccountsPaneController implements GenericFileReadWriteAware {
 			return;
 		}
 		controller.removeDefaultFeePayer((String) network);
-		controller.settingsPaneController.initializeSettingsPane();
+		controller.settingsPaneController.initializePane();
 		setupFeePayerChoiceBox();
 		controller.settingsPaneController.setupFeePayerChoicebox();
 	}
@@ -1331,7 +1331,7 @@ public class AccountsPaneController implements GenericFileReadWriteAware {
 	private void handleNetworkStringFinish() {
 		setupFeePayers();
 		setupFeePayerChoiceBox();
-		initializeAccountPane();
+		initializePane();
 	}
 
 	private void updateNicknamesFile(
@@ -1521,7 +1521,7 @@ public class AccountsPaneController implements GenericFileReadWriteAware {
 				CompleteKeysPopup.display(controller.keysPaneController.getPublicKeysMap().get(item.getValue()),
 						true);
 		if (displayPopup.equals(true)) {
-			controller.keysPaneController.initializeKeysPane();
+			controller.keysPaneController.initializePane();
 		}
 	}
 
@@ -1846,10 +1846,10 @@ public class AccountsPaneController implements GenericFileReadWriteAware {
 	 * 		if there is an InvalidProtocolException thrown
 	 */
 	private void refreshPanes() throws HederaClientException {
-		initializeAccountPane();
-		controller.keysPaneController.initializeKeysPane();
+		initializePane();
+		controller.keysPaneController.initializePane();
 		controller.homePaneController.setForceUpdate(true);
-		controller.homePaneController.initializeHomePane();
+		controller.homePaneController.initializePane();
 		getAccountsFromFileSystem(accountInfos, idNickNames);
 		controller.setAccountInfoMap(accountInfos);
 		try {
@@ -1882,7 +1882,7 @@ public class AccountsPaneController implements GenericFileReadWriteAware {
 		} catch (final IOException e) {
 			throw new HederaClientException(e);
 		}
-		controller.createPaneController.initializeCreatePane();
+		controller.createPaneController.initializePane();
 	}
 
 	private void archiveOldInfoFile(final Path newPath) throws IOException {
@@ -1972,7 +1972,7 @@ public class AccountsPaneController implements GenericFileReadWriteAware {
 		accountInfos.put(nickname,
 				format(PATH_NAME_EXTENSION, ACCOUNTS_INFO_FOLDER, newAccountID, INFO_EXTENSION));
 		storeAccount(nickname, file.getAbsolutePath());
-		controller.createPaneController.initializeCreatePane();
+		controller.createPaneController.initializePane();
 	}
 
 	/**

--- a/tools-ui/src/main/java/com/hedera/hashgraph/client/ui/Controller.java
+++ b/tools-ui/src/main/java/com/hedera/hashgraph/client/ui/Controller.java
@@ -268,12 +268,19 @@ public class Controller implements Initializable, GenericFileReadWriteAware {
 				final var outs = new LinkedList<>(getOneDriveCredentials().keySet());
 				outs.add(Constants.DEFAULT_INTERNAL_FILES);
 				for (final var inputLocation : outs) {
-					final var homeWatcher = new ReloadFilesWatcher(Path.of(inputLocation, Constants.INPUT_FILES), homePaneController);
+					final var homeWatcher = new ReloadFilesWatcher(Path.of(inputLocation, Constants.INPUT_FILES),
+							() -> {
+								// if files are being removed, while this is trying to reload everything,
+								// it will throw some errors.
+								homePaneController.setForceUpdate(true);
+								homePaneController.initializePane();
+							});
 					final var homeWatcherThread = new Thread(homeWatcher);
 					homeWatcherThread.setDaemon(true);
 					homeWatcherThread.start();
 				}
-				final var accountsWatcher = new ReloadFilesWatcher(Path.of(Constants.DEFAULT_ACCOUNTS), accountsPaneController);
+				final var accountsWatcher = new ReloadFilesWatcher(Path.of(Constants.DEFAULT_ACCOUNTS),
+						accountsPaneController::initializePane);
 				final var accountsWatcherThread = new Thread(accountsWatcher);
 				accountsWatcherThread.setDaemon(true);
 				accountsWatcherThread.start();

--- a/tools-ui/src/main/java/com/hedera/hashgraph/client/ui/CreatePaneController.java
+++ b/tools-ui/src/main/java/com/hedera/hashgraph/client/ui/CreatePaneController.java
@@ -21,7 +21,6 @@ package com.hedera.hashgraph.client.ui;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.google.protobuf.InvalidProtocolBufferException;
-import com.hedera.hashgraph.client.core.action.GenericFileReadWriteAware;
 import com.hedera.hashgraph.client.core.constants.JsonConstants;
 import com.hedera.hashgraph.client.core.enums.Actions;
 import com.hedera.hashgraph.client.core.enums.NetworkEnum;
@@ -228,7 +227,7 @@ import static com.hedera.hashgraph.client.ui.utilities.Utilities.string2Hbar;
 import static com.hedera.hashgraph.client.ui.utilities.Utilities.stripHBarFormat;
 import static java.lang.Thread.sleep;
 
-public class CreatePaneController implements GenericFileReadWriteAware {
+public class CreatePaneController implements SubController {
 
 	// private fields
 	private static final Logger logger = LogManager.getLogger(CreatePaneController.class);
@@ -439,7 +438,8 @@ public class CreatePaneController implements GenericFileReadWriteAware {
 		this.controller = controller;
 	}
 
-	void initializeCreatePane() {
+	@Override
+	public void initializePane() {
 		setupOutputDirectoriesList();
 
 		loadAccountNicknames();
@@ -531,11 +531,9 @@ public class CreatePaneController implements GenericFileReadWriteAware {
 		copyFromAccountHBox.getChildren().clear();
 		copyFromAccountHBox.getChildren().add(autoCompleteNickname);
 		createSignatureRequired.selectedProperty().addListener(
-				(observableValue, aBoolean, t1) -> createRSRLabel.setText(Boolean.TRUE.equals(t1) ? "true" : "false"
-				));
+				(observableValue, aBoolean, t1) -> createRSRLabel.setText(String.valueOf(t1)));
 		declineStakingRewards.selectedProperty().addListener(
-				(observableValue, aBoolean, t1) -> declineStakingRewardsLabel.setText(Boolean.TRUE.equals(t1) ? "true" : "false"
-				));
+				(observableValue, aBoolean, t1) -> declineStakingRewardsLabel.setText(String.valueOf(t1)));
 
 		createAccountMemo.textProperty().addListener(
 				(observableValue, s, t1) -> setMemoByteCounter(createAccountMemo, createMemoByteCount));
@@ -569,9 +567,9 @@ public class CreatePaneController implements GenericFileReadWriteAware {
 						REGEX));
 
 		updateReceiverSignatureRequired.selectedProperty().addListener(
-				(observableValue, aBoolean, t1) -> updateRSRLabel.setText(Boolean.TRUE.equals(t1) ? "true" : "false"));
+				(observableValue, aBoolean, t1) -> updateRSRLabel.setText(String.valueOf(t1)));
 		declineStakingRewardsNew.selectedProperty().addListener(
-				(observableValue, aBoolean, t1) -> declineStakingRewardsLabelUpdate.setText(Boolean.TRUE.equals(t1) ? "true" : "false"));
+				(observableValue, aBoolean, t1) -> declineStakingRewardsLabelUpdate.setText(String.valueOf(t1)));
 		loadAccountNicknames();
 		final var updateFromNickName = new AutoCompleteNickname(accountNickNames);
 		updateFromNickName.setVisible(false);
@@ -584,7 +582,14 @@ public class CreatePaneController implements GenericFileReadWriteAware {
 
 		updateAccountID.setOnKeyPressed(keyEvent -> {
 			final var keyCode = keyEvent.getCode();
-			if (keyCode.equals(KeyCode.TAB) || keyCode.equals(KeyCode.ENTER)) {
+			if (keyCode.equals(KeyCode.ENTER)) {
+				findAccountInfoAndPreloadFields();
+			}
+		});
+
+		updateAccountID.focusedProperty().addListener((obs, oldValue, newValue) -> {
+			// If newValue is false (focus is lost) AND the field isn't empty, try to preload the files
+			if (Boolean.FALSE.equals(newValue) && !"".equals(updateAccountID.getText())) {
 				findAccountInfoAndPreloadFields();
 			}
 		});
@@ -1011,8 +1016,9 @@ public class CreatePaneController implements GenericFileReadWriteAware {
 		updateAutoRenew.setText(String.valueOf(controller.getAutoRenewPeriod()));
 		updateReceiverSignatureRequired.setSelected(false);
 		updateARPOriginal.clear();
-		updateRSROriginal.setText("???");
+		updateRSROriginal.setText("unknown");
 		declineStakingRewardsOriginal.setText("unknown");
+		declineStakingRewardsNew.setSelected(false);
 		stakedAccountIdOriginal.setPromptText("unknown");
 		stakedNodeIdOriginal.setPromptText("unknown");
 		updateOriginalKey.setContent(new HBox());
@@ -1039,6 +1045,8 @@ public class CreatePaneController implements GenericFileReadWriteAware {
 			final var accountInfo = accountsInfoMap.get(account);
 			updateARPOriginal.setText(String.format("%d s", accountInfo.autoRenewPeriod.getSeconds()));
 			updateRSROriginal.setText(String.valueOf(accountInfo.isReceiverSignatureRequired));
+			// Set the new value to be the same as the original
+			updateReceiverSignatureRequired.setSelected(accountInfo.isReceiverSignatureRequired);
 			controller.loadPubKeys();
 			final var jsonObjectKey = EncryptionUtils.keyToJson(accountInfo.key);
 			originalKey = EncryptionUtils.keyToJson(accountInfo.key);
@@ -1062,6 +1070,8 @@ public class CreatePaneController implements GenericFileReadWriteAware {
 					stakedNodeIdOriginal.setPromptText("unset");
 				}
 				declineStakingRewardsOriginal.setText(String.valueOf(accountInfo.stakingInfo.declineStakingReward));
+				// Set the new value to be the same as the original
+				declineStakingRewardsNew.setSelected(accountInfo.stakingInfo.declineStakingReward);
 			} else {
 				stakedAccountIdOriginal.setText("");
 				stakedNodeIdOriginal.setText("");
@@ -1607,7 +1617,7 @@ public class CreatePaneController implements GenericFileReadWriteAware {
 		}
 
 		controller.homePaneController.setForceUpdate(true);
-		initializeCreatePane();
+		initializePane();
 		selectTransactionType.setValue(SELECT_STRING);
 	}
 
@@ -2370,14 +2380,14 @@ public class CreatePaneController implements GenericFileReadWriteAware {
 		}
 
 		// Auto renew
-		final var originalARP = info != null ? info.autoRenewPeriod.getSeconds() : 0;
+		final var originalARP = (info != null ? info.autoRenewPeriod.getSeconds() : 0);
 		final var newARP = Long.parseLong(updateAutoRenew.getText());
 		if (originalARP != newARP) {
 			input.addProperty(AUTO_RENEW_PERIOD_FIELD_NAME, newARP);
 		}
 
 		// Receiver Sig Required
-		final var originalSigRequired = info != null && info.isReceiverSignatureRequired;
+		final var originalSigRequired = (info != null && info.isReceiverSignatureRequired);
 		final var newSigRequired = updateReceiverSignatureRequired.isSelected();
 		if (originalSigRequired != newSigRequired) {
 			input.addProperty(RECEIVER_SIGNATURE_REQUIRED_FIELD_NAME, newSigRequired);
@@ -2408,7 +2418,7 @@ public class CreatePaneController implements GenericFileReadWriteAware {
 			input.addProperty(STAKED_NODE_ID_FIELD_NAME, Long.parseLong(stakedNodeIdNew.getText()));
 		}
 
-		final var originalDeclineStakingRewardsNew = info != null && info.stakingInfo != null && info.stakingInfo.declineStakingReward;
+		final var originalDeclineStakingRewardsNew = (info != null && info.stakingInfo != null && info.stakingInfo.declineStakingReward);
 		if (originalDeclineStakingRewardsNew != declineStakingRewardsNew.isSelected()) {
 			input.addProperty(DECLINE_STAKING_REWARDS_FIELD_NAME, declineStakingRewardsNew.isSelected());
 		}
@@ -2946,7 +2956,7 @@ public class CreatePaneController implements GenericFileReadWriteAware {
 
 		moveToOutput(files, remoteLocation);
 
-		// remove all temporary files from local storage;
+		// Remove all temporary files from local storage
 		try {
 			if (txFile.exists()) {
 				Files.delete(txFile.toPath());
@@ -2968,8 +2978,8 @@ public class CreatePaneController implements GenericFileReadWriteAware {
 		}
 
 		//reload the home pane, to show the transaction
-		controller.homePaneController.initializeHomePane();
-		initializeCreatePane();
+		controller.homePaneController.initializePane();
+		initializePane();
 		selectTransactionType.setValue(SELECT_STRING);
 	}
 
@@ -3127,7 +3137,7 @@ public class CreatePaneController implements GenericFileReadWriteAware {
 				logger.error("Unknown transaction");
 		}
 
-		initializeCreatePane();
+		initializePane();
 		selectTransactionType.setValue(type);
 	}
 
@@ -3241,7 +3251,7 @@ public class CreatePaneController implements GenericFileReadWriteAware {
 			}
 			PopupMessage.display("Update succeeded",
 					String.format("Contents update for file %s succeeded", updateFileID.getText()));
-			initializeCreatePane();
+			initializePane();
 		});
 
 		task.setOnCancelled(workerStateEvent -> {
@@ -3257,7 +3267,7 @@ public class CreatePaneController implements GenericFileReadWriteAware {
 			PopupMessage.display("Update failed",
 					String.format("File update failed with error %s. Please review the transaction and try again.",
 							errorMessage));
-			initializeCreatePane();
+			initializePane();
 		});
 
 		task.setOnFailed(workerStateEvent -> {
@@ -3343,8 +3353,8 @@ public class CreatePaneController implements GenericFileReadWriteAware {
 			logger.info(receipt);
 			showReceiptOnPopup(transaction, receipt);
 			storeReceipt(receipt, transactionName, rf.getTransactionType().toString());
-			controller.homePaneController.initializeHomePane();
-			initializeCreatePane();
+			controller.homePaneController.initializePane();
+			initializePane();
 			selectTransactionType.setValue(SELECT_STRING);
 		} catch (final InterruptedException e) {
 			logger.error(e.getMessage());
@@ -3371,7 +3381,7 @@ public class CreatePaneController implements GenericFileReadWriteAware {
 
 
 	private TreeView<String> getKeyTree(final TransactionFile transactionFile) {
-		final KeyList key;
+		final Key key;
 		switch (transactionFile.getTransaction().getTransactionType()) {
 			case CRYPTO_CREATE:
 				key = ((ToolCryptoCreateTransaction) transactionFile.getTransaction()).getKey();

--- a/tools-ui/src/main/java/com/hedera/hashgraph/client/ui/HistoryPaneController.java
+++ b/tools-ui/src/main/java/com/hedera/hashgraph/client/ui/HistoryPaneController.java
@@ -19,7 +19,6 @@
 package com.hedera.hashgraph.client.ui;
 
 import com.google.gson.JsonArray;
-import com.hedera.hashgraph.client.core.action.GenericFileReadWriteAware;
 import com.hedera.hashgraph.client.core.constants.Constants;
 import com.hedera.hashgraph.client.core.enums.Actions;
 import com.hedera.hashgraph.client.core.enums.FileType;
@@ -105,7 +104,7 @@ import static java.lang.String.join;
 import static java.nio.file.Files.deleteIfExists;
 import static javafx.beans.binding.Bindings.createObjectBinding;
 
-public class HistoryPaneController implements GenericFileReadWriteAware {
+public class HistoryPaneController implements SubController {
 	private static final Logger logger = LogManager.getLogger(HistoryPaneController.class);
 	public static final String RESET_ICON = "icons/sign-back.png";
 	public static final String SENT_ICON = "icons/icons8-sent-100.png";
@@ -161,7 +160,8 @@ public class HistoryPaneController implements GenericFileReadWriteAware {
 		this.controller = controller;
 	}
 
-	void initializeHistoryPane() {
+	@Override
+	public void initializePane() {
 		loadHistory();
 		setupTable();
 		setupPredicates();
@@ -492,7 +492,7 @@ public class HistoryPaneController implements GenericFileReadWriteAware {
 						tableList.add(row, historyData);
 						button.setDisable(true);
 						controller.homePaneController.setForceUpdate(true);
-						controller.homePaneController.initializeHomePane();
+						controller.homePaneController.initializePane();
 					}
 
 					private int getRow(final HistoryData historyData) {
@@ -1002,9 +1002,9 @@ public class HistoryPaneController implements GenericFileReadWriteAware {
 	 */
 	public void rebuildHistory() throws IOException {
 		deleteIfExists(Path.of(Constants.HISTORY_MAP));
-		initializeHistoryPane();
+		initializePane();
 		controller.homePaneController.setForceUpdate(true);
-		controller.homePaneController.initializeHomePane();
+		controller.homePaneController.initializePane();
 	}
 
 	/**

--- a/tools-ui/src/main/java/com/hedera/hashgraph/client/ui/InitialStartupPaneController.java
+++ b/tools-ui/src/main/java/com/hedera/hashgraph/client/ui/InitialStartupPaneController.java
@@ -19,7 +19,6 @@
 package com.hedera.hashgraph.client.ui;
 
 import com.google.gson.JsonObject;
-import com.hedera.hashgraph.client.core.action.GenericFileReadWriteAware;
 import com.hedera.hashgraph.client.core.constants.Messages;
 import com.hedera.hashgraph.client.core.enums.SetupPhase;
 import com.hedera.hashgraph.client.core.exceptions.HederaClientException;
@@ -58,7 +57,7 @@ import static com.hedera.hashgraph.client.core.constants.Constants.DRIVE_LIMIT;
 import static com.hedera.hashgraph.client.core.constants.Constants.INITIAL_MAP_LOCATION;
 import static com.hedera.hashgraph.client.core.constants.Constants.USER_PROPERTIES;
 
-public class InitialStartupPaneController implements GenericFileReadWriteAware {
+public class InitialStartupPaneController implements SubController {
 
 	private static final Logger logger = LogManager.getLogger(InitialStartupPaneController.class);
 
@@ -132,7 +131,8 @@ public class InitialStartupPaneController implements GenericFileReadWriteAware {
 	/**
 	 * Pane initialization
 	 */
-	void initializeStartupPane() {
+	@Override
+	public void initializePane() {
 		properties =
 				new UserAccessibleProperties(DEFAULT_STORAGE + File.separator + USER_PROPERTIES, "");
 
@@ -215,12 +215,12 @@ public class InitialStartupPaneController implements GenericFileReadWriteAware {
 		controller.homePane.setVisible(true);
 		controller.setDisableButtons(false);
 
-		controller.homePaneController.initializeHomePane();
-		controller.accountsPaneController.initializeAccountPane();
-		controller.historyPaneController.initializeHistoryPane();
-		controller.keysPaneController.initializeKeysPane();
-		controller.createPaneController.initializeCreatePane();
-		controller.settingsPaneController.initializeSettingsPane();
+		controller.homePaneController.initializePane();
+		controller.accountsPaneController.initializePane();
+		controller.historyPaneController.initializePane();
+		controller.keysPaneController.initializePane();
+		controller.createPaneController.initializePane();
+		controller.settingsPaneController.initializePane();
 
 		try {
 			Files.deleteIfExists(Path.of(INITIAL_MAP_LOCATION));
@@ -241,7 +241,7 @@ public class InitialStartupPaneController implements GenericFileReadWriteAware {
 				PopupMessage.display("Confirm", Messages.INITIAL_SETUP_RESET_MESSAGE, true, "Yes", "No"))) {
 			FileUtils.deleteDirectory(new File(controller.getPreferredStorageDirectory()));
 			controller.resetProperties();
-			initializeStartupPane();
+			initializePane();
 		}
 	}
 

--- a/tools-ui/src/main/java/com/hedera/hashgraph/client/ui/KeysPaneController.java
+++ b/tools-ui/src/main/java/com/hedera/hashgraph/client/ui/KeysPaneController.java
@@ -22,7 +22,6 @@ import com.google.common.collect.Sets;
 import com.google.common.primitives.Chars;
 import com.google.gson.JsonObject;
 import com.google.protobuf.InvalidProtocolBufferException;
-import com.hedera.hashgraph.client.core.action.GenericFileReadWriteAware;
 import com.hedera.hashgraph.client.core.constants.ErrorMessages;
 import com.hedera.hashgraph.client.core.constants.Messages;
 import com.hedera.hashgraph.client.core.exceptions.HederaClientException;
@@ -76,7 +75,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 
-import java.awt.Toolkit;
+import java.awt.*;
 import java.awt.datatransfer.StringSelection;
 import java.io.BufferedWriter;
 import java.io.File;
@@ -115,7 +114,7 @@ import static org.apache.commons.io.FileUtils.contentEquals;
 import static org.apache.commons.io.FileUtils.copyFile;
 import static org.apache.commons.io.FileUtils.moveFile;
 
-public class KeysPaneController implements GenericFileReadWriteAware {
+public class KeysPaneController implements SubController {
 
 	private static final Logger logger = LogManager.getLogger(KeysPaneController.class);
 	private static final String MISSING_HASHCODE_MESSAGE =
@@ -198,7 +197,8 @@ public class KeysPaneController implements GenericFileReadWriteAware {
 		this.controller = controller;
 	}
 
-	public void initializeKeysPane() {
+	@Override
+	public void initializePane() {
 		try {
 			currentHashCode = String.valueOf(controller.getMnemonicHashCode());
 
@@ -534,7 +534,7 @@ public class KeysPaneController implements GenericFileReadWriteAware {
 		final var pubKeyAddress = publicKeysMap.get(rowData.getKeyName() + "." + PUB_EXTENSION);
 		final var answer = CompleteKeysPopup.display(pubKeyAddress, rowData.getAccountList(), true);
 		if (Boolean.TRUE.equals(answer)) {
-			initializeKeysPane();
+			initializePane();
 		}
 	}
 
@@ -824,7 +824,7 @@ public class KeysPaneController implements GenericFileReadWriteAware {
 		}
 		populatePublicKeysMap();
 		populatePrivateKeysMap();
-		initializeKeysPane();
+		initializePane();
 		closeGenerateKeys();
 		fill(password, 'x');
 	}
@@ -876,7 +876,7 @@ public class KeysPaneController implements GenericFileReadWriteAware {
 		resetKeyRecoveryBox();
 		populatePrivateKeysMap();
 		initializeIndexMap();
-		initializeKeysPane();
+		initializePane();
 	}
 
 	private boolean createKeyStoreForAccount(final int index, final char[] password) {
@@ -1198,7 +1198,7 @@ public class KeysPaneController implements GenericFileReadWriteAware {
 		counter += handleDuplicates(duplicates);
 
 		if (counter > 0) {
-			initializeKeysPane();
+			initializePane();
 		}
 	}
 

--- a/tools-ui/src/main/java/com/hedera/hashgraph/client/ui/SettingsPaneController.java
+++ b/tools-ui/src/main/java/com/hedera/hashgraph/client/ui/SettingsPaneController.java
@@ -21,7 +21,6 @@ package com.hedera.hashgraph.client.ui;
 import com.google.common.net.InetAddresses;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-import com.hedera.hashgraph.client.core.action.GenericFileReadWriteAware;
 import com.hedera.hashgraph.client.core.constants.Constants;
 import com.hedera.hashgraph.client.core.constants.Messages;
 import com.hedera.hashgraph.client.core.constants.ToolTipMessages;
@@ -84,7 +83,7 @@ import static com.hedera.hashgraph.client.core.constants.ToolTipMessages.VALID_D
 import static javafx.scene.control.Alert.AlertType;
 import static javafx.scene.control.Control.USE_COMPUTED_SIZE;
 
-public class SettingsPaneController implements GenericFileReadWriteAware {
+public class SettingsPaneController implements SubController {
 
 	private static final Logger logger = LogManager.getLogger(SettingsPaneController.class);
 	private static final String REGEX = "\\D";
@@ -161,7 +160,8 @@ public class SettingsPaneController implements GenericFileReadWriteAware {
 		this.controller = controller;
 	}
 
-	void initializeSettingsPane() {
+	@Override
+	public void initializePane() {
 		try {
 			settingScrollPane.setFitToWidth(true);
 			// bindings
@@ -812,7 +812,7 @@ public class SettingsPaneController implements GenericFileReadWriteAware {
 		final var zero = Identifier.ZERO;
 		zero.setNetworkName(controller.getCurrentNetwork());
 		controller.setDefaultFeePayer(zero);
-		controller.accountsPaneController.initializeAccountPane();
+		controller.accountsPaneController.initializePane();
 		addFeePayerAction();
 	}
 

--- a/tools-ui/src/main/java/com/hedera/hashgraph/client/ui/SubController.java
+++ b/tools-ui/src/main/java/com/hedera/hashgraph/client/ui/SubController.java
@@ -1,0 +1,25 @@
+/*
+ * Hedera Transaction Tool
+ *
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.hashgraph.client.ui;
+
+import com.hedera.hashgraph.client.core.action.GenericFileReadWriteAware;
+
+public interface SubController extends GenericFileReadWriteAware {
+    void initializePane();
+}

--- a/tools-ui/src/main/java/com/hedera/hashgraph/client/ui/utilities/KeyStructureUtility.java
+++ b/tools-ui/src/main/java/com/hedera/hashgraph/client/ui/utilities/KeyStructureUtility.java
@@ -56,8 +56,6 @@ public class KeyStructureUtility implements GenericFileReadWriteAware {
 	private final Controller controller;
 	// contains all .pub files' content and file name
 	private Map<String, Path> pubFiles = new HashMap<>();
-	// is loaded when the key structure is shown
-	private final Map<TreeItem<String>, JsonObject> keyJsonItems = new HashMap<>();
 
 	public KeyStructureUtility(final Controller controller) {
 		this.controller = controller;
@@ -142,7 +140,6 @@ public class KeyStructureUtility implements GenericFileReadWriteAware {
 		} else {
 			node = showSimpleKey(keyJson);
 		}
-		keyJsonItems.put(node, keyJson);
 		return node;
 	}
 
@@ -156,8 +153,6 @@ public class KeyStructureUtility implements GenericFileReadWriteAware {
 	public TreeView<String> buildKeyTreeView(final JsonObject keyJson) {
 		final var keyTreeView = new TreeView<String>();
 		final var root = new TreeItem<String>();
-		final var rootJson = new JsonObject();
-		keyJsonItems.put(root, rootJson);
 		final var keyItem = showKey(keyJson);
 		root.getChildren().add(keyItem);
 		keyTreeView.setRoot(root);

--- a/tools-ui/src/main/java/com/hedera/hashgraph/client/ui/utilities/ReloadFilesService.java
+++ b/tools-ui/src/main/java/com/hedera/hashgraph/client/ui/utilities/ReloadFilesService.java
@@ -18,17 +18,17 @@
 
 package com.hedera.hashgraph.client.ui.utilities;
 
-import com.hedera.hashgraph.client.ui.HomePaneController;
+import com.hedera.hashgraph.client.ui.SubController;
 import javafx.application.Platform;
 import javafx.concurrent.ScheduledService;
 import javafx.concurrent.Task;
 
 public class ReloadFilesService extends ScheduledService<Void> {
 
-	private final HomePaneController controller;
+	private final SubController controller;
 
-	public ReloadFilesService(final HomePaneController homePaneController) {
-		this.controller = homePaneController;
+	public ReloadFilesService(final SubController subController) {
+		this.controller = subController;
 	}
 
 	@Override
@@ -37,7 +37,7 @@ public class ReloadFilesService extends ScheduledService<Void> {
 			@Override
 			protected Void call() {
 				// other auto reloading panes can go here
-				Platform.runLater(controller::initializeHomePane);
+				Platform.runLater(controller::initializePane);
 				return null;
 			}
 		};

--- a/tools-ui/src/main/java/com/hedera/hashgraph/client/ui/utilities/ReloadFilesWatcher.java
+++ b/tools-ui/src/main/java/com/hedera/hashgraph/client/ui/utilities/ReloadFilesWatcher.java
@@ -18,7 +18,6 @@
 
 package com.hedera.hashgraph.client.ui.utilities;
 
-import com.hedera.hashgraph.client.ui.SubController;
 import javafx.application.Platform;
 
 import java.io.IOException;
@@ -31,19 +30,19 @@ import java.nio.file.WatchService;
 public class ReloadFilesWatcher implements Runnable {
     private final WatchService watcher;
     private final WatchKey key;
-    private final SubController subController;
+    private final Runnable runnable;
 
 
     /**
      * Creates a WatchService and registers the given directory
      */
-    public ReloadFilesWatcher(Path dir, SubController subController) throws IOException {
+    public ReloadFilesWatcher(Path dir, Runnable method) throws IOException {
         this.watcher = FileSystems.getDefault().newWatchService();
         this.key = dir.register(watcher,
                 StandardWatchEventKinds.ENTRY_CREATE,
                 StandardWatchEventKinds.ENTRY_DELETE,
                 StandardWatchEventKinds.ENTRY_MODIFY);
-        this.subController = subController;
+        this.runnable = method;
 
         Runtime.getRuntime().addShutdownHook(new Thread(() -> {
             try {
@@ -68,7 +67,7 @@ public class ReloadFilesWatcher implements Runnable {
                 // If take happened, this should always be true
                 if (!watchKey.pollEvents().isEmpty()) {
                     // Initialize the pane
-                    Platform.runLater(subController::initializePane);
+                    Platform.runLater(runnable);
                 }
 
                 // Reset key, if it fails, break from the loop

--- a/tools-ui/src/main/java/com/hedera/hashgraph/client/ui/utilities/ReloadFilesWatcher.java
+++ b/tools-ui/src/main/java/com/hedera/hashgraph/client/ui/utilities/ReloadFilesWatcher.java
@@ -1,0 +1,82 @@
+/*
+ * Hedera Transaction Tool
+ *
+ * Copyright (C) 2018 - 2021 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.hashgraph.client.ui.utilities;
+
+import com.hedera.hashgraph.client.ui.SubController;
+import javafx.application.Platform;
+
+import java.io.IOException;
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
+import java.nio.file.StandardWatchEventKinds;
+import java.nio.file.WatchKey;
+import java.nio.file.WatchService;
+
+public class ReloadFilesWatcher implements Runnable {
+    private final WatchService watcher;
+    private final WatchKey key;
+    private final SubController subController;
+
+
+    /**
+     * Creates a WatchService and registers the given directory
+     */
+    public ReloadFilesWatcher(Path dir, SubController subController) throws IOException {
+        this.watcher = FileSystems.getDefault().newWatchService();
+        this.key = dir.register(watcher,
+                StandardWatchEventKinds.ENTRY_CREATE,
+                StandardWatchEventKinds.ENTRY_DELETE,
+                StandardWatchEventKinds.ENTRY_MODIFY);
+        this.subController = subController;
+
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            try {
+                this.watcher.close();
+            } catch (IOException e) {
+                // Not concerned with an exception at this point.
+            }
+        }));
+    }
+
+    public void run() {
+        try {
+            var keepTrying = true;
+            while (keepTrying) {
+                // Wait for key to be signalled
+                final var watchKey = watcher.take();
+
+                if (this.key != watchKey) {
+                    continue;
+                }
+
+                // If take happened, this should always be true
+                if (!watchKey.pollEvents().isEmpty()) {
+                    // Initialize the pane
+                    Platform.runLater(subController::initializePane);
+                }
+
+                // Reset key, if it fails, break from the loop
+                keepTrying = watchKey.reset();
+            }
+        } catch (InterruptedException e) {
+            // Do nothing except interrupt the current thread (which is likely why this was interrupted anyway)
+            Thread.currentThread().interrupt();
+        }
+    }
+}


### PR DESCRIPTION
The issue that was address is in the BatchFile class. The SigningAccounts was not adding the FeePayerAccount. Now it will add the FeePayer in addition to the Sender if the accounts are different. This means they keys will be auto matched and show up in the tool's home page, ready for signing.

The other issues were somewhat secondary problems encountered during the process of debugging: 

- Now, both accounts and home panes will update when file changes are detected in their respective directory locations using a WatchService. 
- GetAccountInfo will now properly save the key retrieved. 
- Some methods were returning KeyLists where they needed to be returning Keys (this was causing an issue where a single key was nested inside of two keyLists, one of which had a threshold set to null). 
- An extension of "" was passing the validFile method due to the UNKNOWN file type uses "" as its string representation. 
- The SubController interface was added. Initially, it was to help with the home/accounts pane updates. No longer needed, but still cleaner.
- Removed some unnecessary and unused lines from a few classes.